### PR TITLE
Fixed prepare_ansible_target.yml

### DIFF
--- a/02-playbooks/00-simple-playbook-examples/prepare_ansible_target.yml
+++ b/02-playbooks/00-simple-playbook-examples/prepare_ansible_target.yml
@@ -34,7 +34,7 @@
         raw: locale-gen en_US.UTF-8
 
       - name: COMMON | Reconfigure locales
-        raw: dpkg-reconfigure locales
+        raw: update-locale LANG=en_US.UTF-8
       # only run this task block when we've just changed /etc/environment
       when: newenv.changed
 


### PR DESCRIPTION
I noticed that the "prepare Ansible target" playbook was getting stuck when trying to reconfigure the locales. Running the command manually brings up a menu in which a user must select an option. This isn't available when running an Ansible playbook. I have updated it to reconfigure the US.UTF-8 locale automatically so that it doesn't hang on this step. 