### PR TITLE
Fixed creating a playbook on newer versions of python

### DIFF
--- a/02-playbooks/01-playbook-structure/create_playbook.py
+++ b/02-playbooks/01-playbook-structure/create_playbook.py
@@ -86,9 +86,9 @@ def create_playbook(location):
 
     # Create the playbook skeleton
     print("Creating playbook directories")
-    os.mkdir(location, 0755)
+    os.mkdir(location, 0o755)
     for d in dirs_to_create:
-        os.mkdir(os.path.join(location, d), 0755)
+        os.mkdir(os.path.join(location, d), 0o755)
 
     print("Creating playbook files")
     for f in files_to_create:
@@ -116,7 +116,7 @@ def create_role(location, rolename):
     # Create the role skeleton
     print("Creating role directories")
     for d in dirs_to_create:
-        os.mkdir(os.path.join(location, d), 0755)
+        os.mkdir(os.path.join(location, d), 0o755)
 
     print("Creating role files")
     for f in files_to_create:


### PR DESCRIPTION
I found a bug when trying to use your script as part of my work flow. Newer versions of python require that "octal literals must now be specified with a leading "0o" or "0O" instead of "0";"

I've checked to ensure compatibility with older versions, primary 2.7.12 and 3.5.2

Reference:
https://www.python.org/dev/peps/pep-3127/#abstract